### PR TITLE
set laser intensity to 0 on M5

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1363,6 +1363,7 @@ void process_commands()
       break;
     case 5:  //M5 stop firing laser
 	  laser.status = LASER_OFF;
+    laser.intensity = (float) 0.0;
           lcd_update();
 	  prepare_move();
       break;


### PR DESCRIPTION
I had an issue where the laser would fire during travel if using auto home from the LCD after running a job. This seems to fix that but might not be correct solution.
